### PR TITLE
prevent saving corrupted audio file, download with file ultimated.jso…

### DIFF
--- a/download_all_mp3.py
+++ b/download_all_mp3.py
@@ -9,14 +9,19 @@ import requests
 
 MP3_FILENAME_EXTENSION = '.mp3'
 DIR_PATH = 'download/'
-TOTAL_THREADS = 30
-DATA_FILE = 'data.json'
+TOTAL_THREADS = 40
+DATA_FILE = 'ultimate.json'
 
 
 def download_mp3(word, url, dir_path):
-    filename = os.path.join(dir_path, word + MP3_FILENAME_EXTENSION)
-    with open(filename, 'wb') as file:
-        file.write(requests.get(url).content)
+    temp=requests.get(url).content
+    if "!DOCT" in str(temp[:6]): # <!DOCTYPE html>
+        raise Exception
+    else :
+        #print('ok')
+        filename = os.path.join(dir_path, word + MP3_FILENAME_EXTENSION)
+        with open(filename, 'wb') as file:
+           file.write(temp)
 
 
 # split a dictionary into a list of dictionaries
@@ -45,10 +50,25 @@ class DownloadWorker(Thread):
             # if os.path.exists(os.path.join(self.dir_path, word + MP3_FILENAME_EXTENSION)):
             #     self.statistics.decrease_total()
             #     continue
+			
             current = self.statistics.increase_current()
             print('(' + str(current) + '/' + str(self.statistics.total) + ') ' + word)
-            download_mp3(word, url, self.dir_path)
+            # download_mp3(word, url, self.dir_path)
 
+            i=0
+            f=1
+            while ((i<len(url)) ): #and (f==1)
+                try:
+                    f=0
+                    if i>0:
+                        download_mp3(word+"("+str(i)+")", url[i], self.dir_path)
+                    else :
+                        download_mp3(word, url[i], self.dir_path)
+                    i+=1
+                except:
+                    #print("Failed for word = "+word)
+                    f=1
+                    i+=1
 
 # provide a mutex on a shared integer representing current progress
 class Statistics:

--- a/download_all_mp3.py
+++ b/download_all_mp3.py
@@ -15,13 +15,12 @@ DATA_FILE = 'ultimate.json'
 
 def download_mp3(word, url, dir_path):
     temp=requests.get(url).content
-    if "html" in str(temp[:15]): # <!DOCTYPE html> or <html>
-        raise Exception
-    else :
-        #print('ok')
+    if ((temp[1]>=224) and (temp[0]==255)):#1111-1111-111 mp3 first bit sync
         filename = os.path.join(dir_path, word + MP3_FILENAME_EXTENSION)
         with open(filename, 'wb') as file:
            file.write(temp)
+    else :
+        raise Exception
 
 
 # split a dictionary into a list of dictionaries

--- a/download_all_mp3.py
+++ b/download_all_mp3.py
@@ -15,7 +15,7 @@ DATA_FILE = 'ultimate.json'
 
 def download_mp3(word, url, dir_path):
     temp=requests.get(url).content
-    if "!DOCT" in str(temp[:6]): # <!DOCTYPE html>
+    if "html" in str(temp[:15]): # <!DOCTYPE html> or <html>
         raise Exception
     else :
         #print('ok')


### PR DESCRIPTION
prevent saving corrupted audio file, download with file ultimated.json, download all list

1. I had some mp3 file which contained some html report instead of Audio file 
so i check them in part 'download_mp3' before save them
-this code is not efficient in speed! it needs experts to modify it
2. For me ultimate.json was not work, i find out that 'download_mp3 has issue with array URL in this lookup table
so i assign it one by one
3. you can download all of address for each word. the file with same name will be named by adding number according to index of its URL
+ you can stop download for one word after first valid audio by change above code as follow:

```
                while ((i<len(url)) and (f==1)): 
                try:
                    f=0
                    download_mp3(word, url[i], self.dir_path)
                    i+=1
                except:
                    f=1
                    i+=1
```